### PR TITLE
Disable SuperLinter Python Checks

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -33,6 +33,13 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           LINTER_RULES_PATH: .github/super-linter-configurations
           YAML_ERROR_ON_WARNING: true
+          VALIDATE_PYTHON_BLACK: false
+          VALIDATE_PYTHON_FLAKE8: false
+          VALIDATE_PYTHON_ISORT: false
+          VALIDATE_PYTHON_MYPY: false
+          VALIDATE_PYTHON_PYLINT: false
+          VALIDATE_PYTHON_RUFF: false
+          VALIDATE_PYTHON_PYINK: false
 
   check-markdown-links:
     name: Check Markdown links


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes changes to the `.github/workflows/code-checks.yml` file to disable several Python linters.

Changes to `.github/workflows/code-checks.yml`:

* Disabled validation for the following Python linters: `black`, `flake8`, `isort`, `mypy`, `pylint`, `ruff`, and `pyink`.

Fixes #10 
