### PR TITLE
Validate UV Lock

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -176,6 +176,8 @@ jobs:
         with:
           sarif_file: ruff-results.sarif
           wait-for-processing: true
+      - name: Validate UV Lock
+        run: just uv-lock-check
       - name: Check Python Code Format (Ruff)
         run: just ruff-format-check
         env:

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -22,3 +22,5 @@ pre-commit:
       run: just pinact-check
     Ruff Checks:
       run: just ruff-checks
+    UV Lock Checks:
+      run: just uv-lock-check


### PR DESCRIPTION
# Pull Request

## Description

This pull request introduces a new validation step for UV lock checks in both the GitHub Actions workflow and the pre-commit hooks configuration. These changes ensure that UV lock validation is consistently enforced during code checks and local development.

### Workflow updates:
* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4R179-R180): Added a new step, "Validate UV Lock," in the `jobs:` section to run the `just uv-lock-check` command during the GitHub Actions workflow.

### Pre-commit hook updates:
* [`lefthook.yml`](diffhunk://#diff-ad6a01e589b8b1b214ca310dbb8d2e4314f6c612b921050c73c97455de43884dR25-R26): Added a new pre-commit hook, "UV Lock Checks," to run the `just uv-lock-check` command as part of local development checks.
