### PR TITLE
Bump astral-sh/setup-uv from to 6.0.1

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -89,10 +89,8 @@ jobs:
       - name: Set up Just
         uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3.0.0
       - name: Install Python and UV
-        uses: astral-sh/setup-uv@f94ec6bedd8674c4426838e6b50417d36b6ab231 # v5.3.1
-        with:
-          pyproject-file: "pyproject.toml"
-          enable-cache: true
+        uses: astral-sh/setup-uv@6b9c6063abd6010835644d4c2e1bef4cf5cd0fca # v6.0.1
+
       - name: Install Python Dependencies
         run: just install
       - name: Run zizmor 🌈
@@ -115,7 +113,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Install the latest version of uv
-        uses: astral-sh/setup-uv@f94ec6bedd8674c4426838e6b50417d36b6ab231 # v5.3.1
+        uses: astral-sh/setup-uv@6b9c6063abd6010835644d4c2e1bef4cf5cd0fca # v6.0.1
         with:
           version: "latest"
       - name: Run Lefthook Validate
@@ -156,7 +154,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Install Python and UV
-        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
+        uses: astral-sh/setup-uv@6b9c6063abd6010835644d4c2e1bef4cf5cd0fca # v6.0.1
         with:
           pyproject-file: "pyproject.toml"
           enable-cache: true

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -90,7 +90,6 @@ jobs:
         uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3.0.0
       - name: Install Python and UV
         uses: astral-sh/setup-uv@6b9c6063abd6010835644d4c2e1bef4cf5cd0fca # v6.0.1
-
       - name: Install Python Dependencies
         run: just install
       - name: Run zizmor 🌈
@@ -155,9 +154,6 @@ jobs:
           persist-credentials: false
       - name: Install Python and UV
         uses: astral-sh/setup-uv@6b9c6063abd6010835644d4c2e1bef4cf5cd0fca # v6.0.1
-        with:
-          pyproject-file: "pyproject.toml"
-          enable-cache: true
       - name: Set up Just
         uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3
       - name: Install Python Dependencies


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the `astral-sh/setup-uv` action in the `.github/workflows/code-checks.yml` file to use version `v6.0.1` across multiple steps, ensuring consistency and leveraging the latest features and fixes.

Updates to GitHub Actions workflows:

* Updated the `astral-sh/setup-uv` action from `v5.3.1` to `v6.0.1` for the "Install Python and UV" step, removing the `pyproject-file` and `enable-cache` parameters. (`.github/workflows/code-checks.yml`, [.github/workflows/code-checks.ymlL92-R92](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L92-R92))
* Updated the `astral-sh/setup-uv` action from `v5.3.1` to `v6.0.1` for the "Install the latest version of uv" step. (`.github/workflows/code-checks.yml`, [.github/workflows/code-checks.ymlL118-R115](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L118-R115))
* Updated the `astral-sh/setup-uv` action from `v5.4.2` to `v6.0.1` for another "Install Python and UV" step, also removing the `pyproject-file` and `enable-cache` parameters. (`.github/workflows/code-checks.yml`, [.github/workflows/code-checks.ymlL159-R156](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L159-R156))