### PR TITLE
Add CodeLimit Job

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -180,3 +180,18 @@ jobs:
         run: just ruff-lint-check
         env:
           RUFF_OUTPUT_FORMAT: "github"
+
+  run-codelimit:
+    name: Run CodeLimit
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4.2.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: "Run CodeLimit"
+        uses: getcodelimit/codelimit-action@a036c6897be9ccf69cde9dfe50eafa8cd79c98f8 # v1


### PR DESCRIPTION
# Pull Request

## Description

This pull request adds a new job to the GitHub Actions workflow to integrate CodeLimit, a tool for enforcing code limits. 

Key change:

* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4R183-R197): Introduced a new `run-codelimit` job that checks code limits using the `getcodelimit/codelimit-action`. This job includes steps for checking out the repository and running CodeLimit, with appropriate permissions for contents and pull requests.