### PR TITLE
Close Group Update Pull Requests

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -1,4 +1,4 @@
-from playwright.sync_api import sync_playwright, Page
+from playwright.sync_api import Page
 from os import getenv
 from structlog import get_logger, stdlib
 from github import Github
@@ -10,12 +10,14 @@ logger: stdlib.BoundLogger = get_logger()
 
 def app() -> None:
     """Main application function."""
-    with sync_playwright() as p:
-        browser = p.chromium.launch(headless=False)
-        context = browser.new_context()
-        page = context.new_page()
-        sign_into_github(page)
-        get_all_repos()
+    # with sync_playwright() as p:
+    #     browser = p.chromium.launch(headless=False)
+    #     context = browser.new_context()
+    #     page = context.new_page()
+    #     sign_into_github(page)
+    github = setup_github()
+    for repo in get_all_repos(github):
+        close_group_pull_requests(github, repo.full_name)
 
 
 def sign_into_github(page: Page) -> None:
@@ -25,17 +27,26 @@ def sign_into_github(page: Page) -> None:
     page.wait_for_url("https://github.com/", timeout=30000)
 
 
-def get_all_repos() -> PaginatedList[Repository]:
+def setup_github() -> Github:
+    """Set up the GitHub client.
+
+    Returns:
+        Github: An authenticated GitHub client.
+    """
+    auth_token = getenv("GITHUB_TOKEN")
+    if not auth_token:
+        raise ValueError("GITHUB_TOKEN environment variable not set.")
+    github = Github(auth_token)
+    return github
+
+
+def get_all_repos(github: Github) -> PaginatedList[Repository]:
     """Retrieve the list of repositories to analyse.
 
     Returns:
         PaginatedList[Repository]: The list of repositories.
     """
     # Authenticate to GitHub
-    auth_token = getenv("GITHUB_TOKEN")
-    if not auth_token:
-        raise ValueError("GITHUB_TOKEN environment variable not set.")
-    github = Github()
     repositories = github.search_repositories(
         query="user:JackPlowman archived:false is:public",
     )
@@ -45,3 +56,40 @@ def get_all_repos() -> PaginatedList[Repository]:
         repositories=[repository.full_name for repository in repositories],
     )
     return repositories
+
+
+def close_group_pull_requests(github_class: Github, repo_name: str) -> PaginatedList:
+    """Fetches all open pull requests from the specified GitHub repository.
+
+    Args:
+        github_class (Github): An authenticated Github instance.
+        repo_name (str): The name of the repository in the format "owner/repo".
+    """
+    # Get the repository
+    repo = github_class.get_repo(repo_name)
+
+    # Get all open pull requests
+    pulls = repo.get_pulls(state="open")
+    logger.info(
+        "Retrieved open pull requests",
+        repository=repo_name,
+        pull_requests_count=pulls.totalCount,
+    )
+    prs_to_close = [pull for pull in pulls if "updates" in pull.title]
+
+    for pull in prs_to_close:
+        logger.debug(
+            "Closing pull request",
+            repository=repo_name,
+            pull_request_number=pull.number,
+            pull_request_title=pull.title,
+        )
+        pull.create_issue_comment("This PR is being closed as it is a group PR.")
+        pull.edit(state="closed")
+
+    logger.info(
+        "Closed group pull requests",
+        repository=repo_name,
+        closed_pull_requests_count=len(prs_to_close),
+    )
+    return pulls

--- a/src/app.py
+++ b/src/app.py
@@ -1,4 +1,4 @@
-from playwright.sync_api import Page
+from playwright.sync_api import Page, sync_playwright
 from os import getenv
 from structlog import get_logger, stdlib
 from github import Github
@@ -10,14 +10,14 @@ logger: stdlib.BoundLogger = get_logger()
 
 def app() -> None:
     """Main application function."""
-    # with sync_playwright() as p:
-    #     browser = p.chromium.launch(headless=False)
-    #     context = browser.new_context()
-    #     page = context.new_page()
-    #     sign_into_github(page)
-    github = setup_github()
-    for repo in get_all_repos(github):
-        close_group_pull_requests(github, repo.full_name)
+    with sync_playwright() as p:
+        browser = p.chromium.launch(headless=False)
+        context = browser.new_context()
+        page = context.new_page()
+        sign_into_github(page)
+        github = setup_github()
+        for repo in get_all_repos(github):
+            close_group_pull_requests(github, repo.full_name)
 
 
 def sign_into_github(page: Page) -> None:


### PR DESCRIPTION
# Pull Request

## Description

This pull request refactors the GitHub repository and pull request management logic in `src/app.py` to improve modularity and functionality. Key changes include splitting responsibilities into separate functions, introducing a new function to close specific pull requests, and enhancing GitHub client setup with authentication.

### Refactoring and modularization:
* Reorganized import statements in `src/app.py` to follow standard conventions.
* Refactored `get_all_repos()` into two separate functions: `setup_github()` for GitHub client setup with authentication and `get_all_repos()` for fetching repositories using the authenticated client [[1]](diffhunk://#diff-04791d82dd15fdd480f084d7ef65a10789fa5012cb7935f76080763444d48a00L28-R49) [[2]](diffhunk://#diff-04791d82dd15fdd480f084d7ef65a10789fa5012cb7935f76080763444d48a00R59-R95).

### New functionality:
* Added `close_group_pull_requests()` function to identify and close pull requests with "updates" in their title. It logs the details of closed pull requests and adds comments explaining the closure.

### Integration updates:
* Updated the `app()` function to use the new `setup_github()` and `get_all_repos()` functions. Integrated `close_group_pull_requests()` to process repositories and close group pull requests.