### PR TITLE
Add Readme Documentation

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -6,6 +6,10 @@
 install:
     uv sync --all-extras
 
+# Install playwright browsers
+install-browsers:
+    uv run playwright install --with-deps
+
 # Run DependabotTrigger
 run:
     uv run python -m src

--- a/README.md
+++ b/README.md
@@ -1,13 +1,56 @@
-# Repository Name
+# DependabotTrigger
 
 ## Table of Contents
 
-- [Repository Name](#repository-name)
+- [DependabotTrigger](#dependabottrigger)
   - [Table of Contents](#table-of-contents)
+  - [Installation](#installation)
   - [Contributing](#contributing)
+  - [License](#license)
 
-<!-- Add documentation -->
+## Installation
+
+1. Clone the repository:
+
+```bash
+git clone https://github.com/JackPlowman/DependabotTrigger.git
+cd DependabotTrigger
+```
+
+2. To use DependabotTrigger you need to have some prerequisites installed. Install the following tools:
+
+- [Just](https://just.systems/man/en/packages.html)
+- [uv](https://docs.astral.sh/uv/#installation)
+
+3. Install the python dependencies:
+
+```bash
+just install
+```
+
+4. Install playwright browsers:
+
+```bash
+just install-browsers
+```
+
+5. Export the following environment variables:
+
+```bash
+export GITHUB_TOKEN=<your_github_token>
+export GITHUB_USER=<your_github_user>
+```
+
+6. Run the script:
+
+```bash
+just run
+```
 
 ## Contributing
 
 We welcome contributions to the project. Please read the [Contributing Guidelines](docs/CONTRIBUTING.md) for more information.
+
+## License
+
+This project is licensed under the MIT License. See the [LICENSE](LICENSE) file for details.


### PR DESCRIPTION
# Pull Request

## Description

This pull request introduces a new installation process for the `DependabotTrigger` repository, including updates to the `README.md` file and the addition of a `just` command for installing Playwright browsers. These changes aim to improve user onboarding and clarify setup instructions.

### Installation process enhancements:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L1-R56): Added a new "Installation" section with step-by-step instructions, including repository cloning, prerequisites installation, Python dependencies setup, Playwright browser installation, environment variable configuration, and script execution.
* [`Justfile`](diffhunk://#diff-2f90408c2b0302b1cdb7f5d634114750837f940fa82d13057d9c18d0170a7e5cR9-R12): Introduced a new `install-browsers` command to install Playwright browsers and their dependencies via `uv run playwright install --with-deps`.

### Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L1-R56): Updated the repository name to "DependabotTrigger" and revised the Table of Contents to include new sections for "Installation" and "License."