### PR TITLE
Increase Sign In Timeout

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -27,7 +27,7 @@ def sign_into_github(page: Page) -> None:
     """Sign into GitHub using Playwright."""
     page.goto("https://www.github.com/login")
     # Wait 30 seconds for user to enter credentials
-    page.wait_for_url("https://github.com/", timeout=30000)
+    page.wait_for_url("https://github.com/", timeout=120000)
 
 
 def setup_github() -> Github:


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes a small change to the `sign_into_github` function in `src/app.py`. The timeout for waiting on the GitHub URL has been increased from 30 seconds to 120 seconds to allow users more time to enter their credentials.