### PR TITLE
Fix Zizmor SARIF Command

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -86,10 +86,12 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-      - name: Setup Python Dependencies
-        uses: ./.github/actions/setup-python-dependencies
+      - name: Install the latest version of uv
+        uses: astral-sh/setup-uv@6b9c6063abd6010835644d4c2e1bef4cf5cd0fca # v6.0.1
+      - name: Set up Just
+        uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3
       - name: Run zizmor 🌈
-        run: uv run zizmor --format sarif . > results.sarif
+        run: just zizmor-check-sarif
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload SARIF file

--- a/Justfile
+++ b/Justfile
@@ -95,7 +95,11 @@ lefthook-validate:
 
 # Run zizmor checking
 zizmor-check:
-    zizmor . --pedantic --persona=pedantic
+    uvx zizmor . --persona=pedantic
+
+# Run zizmor checking with sarif output
+zizmor-check-sarif:
+    uvx zizmor . --persona=pedantic --format sarif > results.sarif
 
 # ------------------------------------------------------------------------------
 # Pinact


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the workflow and Justfile to streamline the setup of dependencies and improve the execution of the `zizmor` tool. The most important changes include replacing the custom Python dependency setup with specific tools (`uv` and `Just`), and introducing a new command for generating SARIF output.

### Workflow updates:
* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L89-R94): Replaced the custom Python dependency setup action with `astral-sh/setup-uv` and added `extractions/setup-just` for setting up `uv` and `Just`, respectively. Updated the `Run zizmor` step to use the new `just zizmor-check-sarif` command.

### Justfile updates:
* [`Justfile`](diffhunk://#diff-2f90408c2b0302b1cdb7f5d634114750837f940fa82d13057d9c18d0170a7e5cL98-R102): Modified the `zizmor-check` command to use `uvx` instead of `zizmor`. Added a new `zizmor-check-sarif` command to generate SARIF output for `zizmor` checks.