### PR TITLE
Set Python Version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "DependabotTrigger"
 dynamic = ["version"]
-requires-python = ">=3.13"
+requires-python = "~=3.13"
 dependencies = ["structlog==25.3.0", "pygithub==2.6.1", "playwright==1.52.0"]
 
 [project.optional-dependencies]


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the `requires-python` specification in the `pyproject.toml` file to use a compatible release clause instead of a minimum version.

* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L4-R4): Changed `requires-python` from `>=3.13` to `~=3.13` to specify compatibility with Python 3.13.x versions.