### PR TITLE
Bump GitHub Actions and Reusable Workflows

### DIFF
--- a/.github/actions/setup-python-dependencies/action.yml
+++ b/.github/actions/setup-python-dependencies/action.yml
@@ -7,7 +7,7 @@ runs:
     - name: Set up Just
       uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3.0.0
     - name: Install Python and UV
-      uses: astral-sh/setup-uv@f0ec1fc3b38f5e7cd731bb6ce540c5af426746bb # v6.1.0
+      uses: astral-sh/setup-uv@bd01e18f51369d5a26f1651c3cb451d3417e3bba # v6.3.1
     - name: Install Python Dependencies
       shell: bash
       run: just install

--- a/.github/workflows/clean-caches.yml
+++ b/.github/workflows/clean-caches.yml
@@ -12,6 +12,6 @@ jobs:
     name: Clean Caches
     permissions:
       contents: read
-    uses: JackPlowman/reusable-workflows/.github/workflows/common-clean-caches.yml@9aeb375514588fbc71eae2823e3216d43d300501 # v2025.06.16.01
+    uses: JackPlowman/reusable-workflows/.github/workflows/common-clean-caches.yml@06971a92b306e3f7bd9e129c341b6bf7fb68e766 # v2025.07.01.02
     secrets:
       workflow_github_token: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -50,7 +50,7 @@ jobs:
       actions: write
       pull-requests: write
       security-events: write
-    uses: JackPlowman/reusable-workflows/.github/workflows/common-code-checks.yml@9aeb375514588fbc71eae2823e3216d43d300501 # v2025.06.16.01
+    uses: JackPlowman/reusable-workflows/.github/workflows/common-code-checks.yml@06971a92b306e3f7bd9e129c341b6bf7fb68e766 # v2025.07.01.02
     secrets:
       workflow_github_token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -62,7 +62,7 @@ jobs:
     strategy:
       matrix:
         language: [actions, python]
-    uses: JackPlowman/reusable-workflows/.github/workflows/codeql-analysis.yml@9aeb375514588fbc71eae2823e3216d43d300501 # v2025.06.16.01
+    uses: JackPlowman/reusable-workflows/.github/workflows/codeql-analysis.yml@06971a92b306e3f7bd9e129c341b6bf7fb68e766 # v2025.07.01.02
     with:
       language: ${{ matrix.language }}
 
@@ -87,7 +87,7 @@ jobs:
           RUFF_OUTPUT_FILE: "ruff-results.sarif"
         continue-on-error: true
       - name: Upload Ruff analysis results to GitHub
-        uses: github/codeql-action/upload-sarif@ce28f5bb42b7a9f2c824e633a3f6ee835bab6858 # v3.29.0
+        uses: github/codeql-action/upload-sarif@181d5eefc20863364f96762470ba6f862bdef56b # v3.29.2
         with:
           sarif_file: ruff-results.sarif
           wait-for-processing: true

--- a/.github/workflows/pull-request-tasks.yml
+++ b/.github/workflows/pull-request-tasks.yml
@@ -12,6 +12,6 @@ jobs:
     name: Common Pull Request Tasks
     permissions:
       pull-requests: write
-    uses: JackPlowman/reusable-workflows/.github/workflows/common-pull-request-tasks.yml@9aeb375514588fbc71eae2823e3216d43d300501 # v2025.06.16.01
+    uses: JackPlowman/reusable-workflows/.github/workflows/common-pull-request-tasks.yml@06971a92b306e3f7bd9e129c341b6bf7fb68e766 # v2025.07.01.02
     secrets:
       workflow_github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -16,6 +16,6 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-    uses: JackPlowman/reusable-workflows/.github/workflows/common-sync-labels.yml@9aeb375514588fbc71eae2823e3216d43d300501 # v2025.06.16.01
+    uses: JackPlowman/reusable-workflows/.github/workflows/common-sync-labels.yml@06971a92b306e3f7bd9e129c341b6bf7fb68e766 # v2025.07.01.02
     secrets:
       workflow_github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates multiple GitHub Actions and reusable workflows to newer versions, ensuring compatibility and leveraging the latest features and fixes. The updates span across several workflow files.

### Updates to GitHub Actions:

* [`.github/actions/setup-python-dependencies/action.yml`](diffhunk://#diff-4cb40b2fa462f005bed001da7016592925ba7d2dfa1011ffdeedf6a8b0f7fedbL10-R10): Updated the `setup-uv` action from version `v6.1.0` to `v6.3.1`.
* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L90-R90): Updated the `upload-sarif` action from version `v3.29.0` to `v3.29.2`.

### Updates to reusable workflows:

* [`.github/workflows/clean-caches.yml`](diffhunk://#diff-d0394e4336a74cdfc1d4cff05d056b893ac7ff922eacf4448e104a754f386b8dL15-R15): Updated the `common-clean-caches` reusable workflow from version `v2025.06.16.01` to `v2025.07.01.02`.
* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L53-R53): Updated both the `common-code-checks` and `codeql-analysis` reusable workflows from version `v2025.06.16.01` to `v2025.07.01.02`. [[1]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L53-R53) [[2]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L65-R65)
* [`.github/workflows/pull-request-tasks.yml`](diffhunk://#diff-ba6496a5b7a58ac3681ed047691dc32281cc7d548fff1d41201babbd65ad45cfL15-R15): Updated the `common-pull-request-tasks` reusable workflow from version `v2025.06.16.01` to `v2025.07.01.02`.
* [`.github/workflows/sync-labels.yml`](diffhunk://#diff-a877ed9f27d115d95934fd904f2475dcec6ce4125da686dd5b3c75a696fff1c6L19-R19): Updated the `common-sync-labels` reusable workflow from version `v2025.06.16.01` to `v2025.07.01.02`.
