### PR TITLE
Warn on stale dependabot PRs

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -97,7 +97,7 @@ def close_group_pull_requests(
     pull_requests: PaginatedList,
     repo_name: str,
 ) -> None:
-    """Fetches all open pull requests from the specified GitHub repository.
+    """Closes group pull requests in the specified GitHub repository.
 
     Args:
         github_class (Github): An authenticated Github instance.

--- a/src/app.py
+++ b/src/app.py
@@ -5,6 +5,7 @@ from github import Github
 from github.PaginatedList import PaginatedList
 from github.Repository import Repository
 from .custom_logging import set_up_custom_logging
+from datetime import datetime, timedelta, timezone
 
 logger: stdlib.BoundLogger = get_logger()
 
@@ -20,7 +21,9 @@ def app() -> None:
         sign_into_github(page)
         repos = get_all_repos(github)
         for index, repo in enumerate(repos, start=1):
-            close_group_pull_requests(github, repo.full_name)
+            pull_requests = get_pull_requests(github, repo.full_name)
+            close_group_pull_requests(pull_requests, repo.full_name)
+            warn_on_stale_pull_requests(pull_requests, repo.full_name)
             trigger_dependabot(page, repo.full_name)
             logger.info(
                 "Scanned repository",
@@ -70,25 +73,37 @@ def get_all_repos(github: Github) -> list[Repository]:
     )
 
 
-def close_group_pull_requests(github_class: Github, repo_name: str) -> PaginatedList:
+def get_pull_requests(github_class: Github, repo_name: str) -> PaginatedList:
+    """Fetches all open pull requests from the specified GitHub repository.
+
+    Returns:
+        PaginatedList: A list of open pull requests.
+    """
+    # Get the repository
+    repo = github_class.get_repo(repo_name)
+
+    # Get all open pull requests
+    pull_requests = repo.get_pulls(state="open")
+    logger.debug(
+        "Retrieved open pull requests",
+        repository=repo_name,
+        pull_requests_count=pull_requests.totalCount,
+    )
+
+    return pull_requests
+
+
+def close_group_pull_requests(
+    pull_requests: PaginatedList,
+    repo_name: str,
+) -> None:
     """Fetches all open pull requests from the specified GitHub repository.
 
     Args:
         github_class (Github): An authenticated Github instance.
         repo_name (str): The name of the repository in the format "owner/repo".
     """
-    # Get the repository
-    repo = github_class.get_repo(repo_name)
-
-    # Get all open pull requests
-    pulls = repo.get_pulls(state="open")
-    logger.debug(
-        "Retrieved open pull requests",
-        repository=repo_name,
-        pull_requests_count=pulls.totalCount,
-    )
-    prs_to_close = [pull for pull in pulls if "updates" in pull.title]
-
+    prs_to_close = [pull for pull in pull_requests if "updates" in pull.title]
     for pull in prs_to_close:
         logger.debug(
             "Closing pull request",
@@ -96,7 +111,9 @@ def close_group_pull_requests(github_class: Github, repo_name: str) -> Paginated
             pull_request_number=pull.number,
             pull_request_title=pull.title,
         )
-        pull.create_issue_comment("This PR is being closed as it is a group PR.")
+        pull.create_issue_comment(
+            "This PR is being closed as it is a group PR. PR will be recreated by Dependabot.s"
+        )
         pull.edit(state="closed")
 
     logger.debug(
@@ -104,7 +121,39 @@ def close_group_pull_requests(github_class: Github, repo_name: str) -> Paginated
         repository=repo_name,
         closed_pull_requests_count=len(prs_to_close),
     )
-    return pulls
+
+
+def warn_on_stale_pull_requests(
+    pull_requests: PaginatedList,
+    repo_name: str,
+) -> None:
+    """Warns about stale pull requests in the specified GitHub repository.
+
+    Args:
+        pull_requests (PaginatedList): A list of open pull requests.
+        repo_name (str): The name of the repository in the format "owner/repo".
+    """
+    thirty_days_ago = datetime.now(timezone.utc) - timedelta(days=30)
+    stale_prs = [
+        pull
+        for pull in pull_requests
+        if (
+            "updates" not in pull.title
+            and pull.created_at < thirty_days_ago
+            and (
+                "dependabot" in (pull.head.ref or "").lower()
+                or "dependabot" in (pull.base.ref or "").lower()
+            )
+        )
+    ]
+
+    for pull in stale_prs:
+        logger.warning(
+            "Stale pull request found",
+            repository=repo_name,
+            pull_request_number=pull.number,
+            pull_request_title=pull.title,
+        )
 
 
 def trigger_dependabot(page: Page, repository_name: str) -> None:

--- a/src/app.py
+++ b/src/app.py
@@ -8,6 +8,7 @@ from .custom_logging import set_up_custom_logging
 from datetime import datetime, timedelta, timezone
 
 logger: stdlib.BoundLogger = get_logger()
+STALE_PR_THRESHOLD_DAYS = 30
 
 
 def app() -> None:
@@ -133,7 +134,9 @@ def warn_on_stale_pull_requests(
         pull_requests (PaginatedList): A list of open pull requests.
         repo_name (str): The name of the repository in the format "owner/repo".
     """
-    thirty_days_ago = datetime.now(timezone.utc) - timedelta(days=30)
+    thirty_days_ago = datetime.now(timezone.utc) - timedelta(
+        days=STALE_PR_THRESHOLD_DAYS
+    )
     stale_prs = [
         pull
         for pull in pull_requests

--- a/src/app.py
+++ b/src/app.py
@@ -112,7 +112,7 @@ def close_group_pull_requests(
             pull_request_title=pull.title,
         )
         pull.create_issue_comment(
-            "This PR is being closed as it is a group PR. PR will be recreated by Dependabot.s"
+            "This PR is being closed as it is a group PR. PR will be recreated by Dependabot."
         )
         pull.edit(state="closed")
 


### PR DESCRIPTION
# Pull Request

## Description

This pull request refactors and enhances the#148 `src/app.py` file by improving the handling of pull requests and adding functionality to warn about stale pull requests. Key changes include splitting the `close_group_pull_requests` function, introducing a new `warn_on_stale_pull_requests` function, and improving code readability and maintainability.

### Refactoring and Functionality Enhancements:

* **Refactored pull request handling**: The `close_group_pull_requests` function was split into two separate functions: `get_pull_requests` (to fetch open pull requests) and a revised `close_group_pull_requests` (to close group pull requests). This improves code clarity and separation of concerns.
* **Added `warn_on_stale_pull_requests` function**: A new function was introduced to identify and log warnings for stale pull requests that are over 30 days old and related to Dependabot. This helps in monitoring and managing outdated pull requests.

### Codebase Improvements:

* **Updated `app` function**: The `app` function now calls `get_pull_requests`, `close_group_pull_requests`, and `warn_on_stale_pull_requests` in sequence, ensuring all pull request-related operations are handled comprehensively.
* **Improved logging messages**: Enhanced log messages for better debugging and tracking, including more descriptive messages when closing group pull requests and identifying stale pull requests.

### Dependency Updates:

* **Added `datetime` imports**: The `datetime`, `timedelta`, and `timezone` modules were imported to support the new functionality in `warn_on_stale_pull_requests`.

Fixes #148