### PR TITLE
Update License to Licence

### DIFF
--- a/.github/other-configurations/labeller.yml
+++ b/.github/other-configurations/labeller.yml
@@ -25,7 +25,7 @@ markdown:
               [
                 "docs/*.md",
                 "*.md",
-                "LICENSE",
+                "LICENCE",
                 ".github/pull_request_template.md",
               ]
 python:

--- a/README.md
+++ b/README.md
@@ -55,4 +55,4 @@ We welcome contributions to the project. Please read the [Contributing Guideline
 
 ## License
 
-This project is licensed under the MIT License. See the [LICENSE](LICENSE) file for details.
+This project is licensed under the MIT License. See the [LICENCE](LICENCE) file for details.


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the spelling of the license file reference from `LICENSE` to `LICENCE` to ensure consistency across the project configuration and documentation.

Documentation and configuration consistency:

* Updated the license file name in `.github/other-configurations/labeller.yml` from `LICENSE` to `LICENCE` to match the actual file name.
* Updated the license section in `README.md` to reference `LICENCE` instead of `LICENSE`.
