### PR TITLE
Update Reusable Workflows and GitHub Actions

### DIFF
--- a/.github/actions/setup-python-dependencies/action.yml
+++ b/.github/actions/setup-python-dependencies/action.yml
@@ -7,7 +7,7 @@ runs:
     - name: Set up Just
       uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3.0.0
     - name: Install Python and UV
-      uses: astral-sh/setup-uv@e92bafb6253dcd438e0484186d7669ea7a8ca1cc # v6.4.3
+      uses: astral-sh/setup-uv@d9e0f98d3fc6adb07d1e3d37f3043649ddad06a1 # v6.5.0
     - name: Install Python Dependencies
       shell: bash
       run: just install

--- a/.github/workflows/clean-caches.yml
+++ b/.github/workflows/clean-caches.yml
@@ -12,6 +12,6 @@ jobs:
     name: Clean Caches
     permissions:
       contents: read
-    uses: JackPlowman/reusable-workflows/.github/workflows/common-clean-caches.yml@440c19531fe4aaad17688abf374ed722792369c5 # v2025.08.08.01
+    uses: JackPlowman/reusable-workflows/.github/workflows/common-clean-caches.yml@c09fea6437d01213abbf6d3462f8d60fdd1eb9af # v2025.08.15.02
     secrets:
       workflow_github_token: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -51,7 +51,7 @@ jobs:
       actions: write
       pull-requests: write
       security-events: write
-    uses: JackPlowman/reusable-workflows/.github/workflows/common-code-checks.yml@440c19531fe4aaad17688abf374ed722792369c5 # v2025.08.08.01
+    uses: JackPlowman/reusable-workflows/.github/workflows/common-code-checks.yml@c09fea6437d01213abbf6d3462f8d60fdd1eb9af # v2025.08.15.02
     secrets:
       workflow_github_token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -63,7 +63,7 @@ jobs:
     strategy:
       matrix:
         language: [actions, python]
-    uses: JackPlowman/reusable-workflows/.github/workflows/codeql-analysis.yml@440c19531fe4aaad17688abf374ed722792369c5 # v2025.08.08.01
+    uses: JackPlowman/reusable-workflows/.github/workflows/codeql-analysis.yml@c09fea6437d01213abbf6d3462f8d60fdd1eb9af # v2025.08.15.02
     with:
       language: ${{ matrix.language }}
 
@@ -88,7 +88,7 @@ jobs:
           RUFF_OUTPUT_FILE: "ruff-results.sarif"
         continue-on-error: true
       - name: Upload Ruff analysis results to GitHub
-        uses: github/codeql-action/upload-sarif@76621b61decf072c1cee8dd1ce2d2a82d33c17ed # v3.29.8
+        uses: github/codeql-action/upload-sarif@df559355d593797519d70b90fc8edd5db049e7a2 # v3.29.9
         with:
           sarif_file: ruff-results.sarif
           wait-for-processing: true

--- a/.github/workflows/pull-request-tasks.yml
+++ b/.github/workflows/pull-request-tasks.yml
@@ -12,6 +12,6 @@ jobs:
     name: Common Pull Request Tasks
     permissions:
       pull-requests: write
-    uses: JackPlowman/reusable-workflows/.github/workflows/common-pull-request-tasks.yml@440c19531fe4aaad17688abf374ed722792369c5 # v2025.08.08.01
+    uses: JackPlowman/reusable-workflows/.github/workflows/common-pull-request-tasks.yml@c09fea6437d01213abbf6d3462f8d60fdd1eb9af # v2025.08.15.02
     secrets:
       workflow_github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -16,6 +16,6 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-    uses: JackPlowman/reusable-workflows/.github/workflows/common-sync-labels.yml@440c19531fe4aaad17688abf374ed722792369c5 # v2025.08.08.01
+    uses: JackPlowman/reusable-workflows/.github/workflows/common-sync-labels.yml@c09fea6437d01213abbf6d3462f8d60fdd1eb9af # v2025.08.15.02
     secrets:
       workflow_github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates several GitHub Actions workflow dependencies to their latest versions, ensuring improved stability, security, and access to new features. The most significant changes are version bumps for reusable workflow files and key action steps across multiple workflow files.

**Workflow dependency updates:**

* Updated all references to reusable workflow files in `.github/workflows/clean-caches.yml`, `.github/workflows/code-checks.yml`, `.github/workflows/pull-request-tasks.yml`, and `.github/workflows/sync-labels.yml` to use version `v2025.08.15.02` (`c09fea6437d01213abbf6d3462f8d60fdd1eb9af`), replacing the previous version `v2025.08.08.01` (`440c19531fe4aaad17688abf374ed722792369c5`). [[1]](diffhunk://#diff-d0394e4336a74cdfc1d4cff05d056b893ac7ff922eacf4448e104a754f386b8dL15-R15) [[2]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L54-R54) [[3]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L66-R66) [[4]](diffhunk://#diff-ba6496a5b7a58ac3681ed047691dc32281cc7d548fff1d41201babbd65ad45cfL15-R15) [[5]](diffhunk://#diff-a877ed9f27d115d95934fd904f2475dcec6ce4125da686dd5b3c75a696fff1c6L19-R19)

**Action step updates:**

* Updated the `astral-sh/setup-uv` action in `.github/actions/setup-python-dependencies/action.yml` to version `v6.5.0` (`d9e0f98d3fc6adb07d1e3d37f3043649ddad06a1`), up from `v6.4.3`.
* Bumped the `github/codeql-action/upload-sarif` step in `.github/workflows/code-checks.yml` to version `v3.29.9` (`df559355d593797519d70b90fc8edd5db049e7a2`), up from `v3.29.8`.
