### PR TITLE
Improve Ruff Pyproject Configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,6 @@ package = false
 target-version = "py313"
 
 [tool.ruff.lint]
-extend-select = ["E501"]
 select = ["ALL"]
 
 ignore = [
@@ -30,26 +29,6 @@ ignore = [
 
 fixable = ["ALL"]
 unfixable = []
-
-exclude = [
-  ".bzr",
-  ".direnv",
-  ".eggs",
-  ".git",
-  ".hg",
-  ".mypy_cache",
-  ".nox",
-  ".pants.d",
-  ".pytype",
-  ".ruff_cache",
-  ".svn",
-  ".tox",
-  ".venv",
-  "__pypackages__",
-  "_build",
-]
-
-dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 
 [tool.ruff.lint.pydocstyle]
 convention = "google"


### PR DESCRIPTION
# Pull Request

## Description

This pull request makes changes to the `pyproject.toml` configuration, primarily simplifying the linting settings for the project.

**Linting configuration updates:**

* Removed the `extend-select` option for linting, now relying solely on the `select = ["ALL"]` setting for rule selection.
* Deleted the `exclude` list and the `dummy-variable-rgx` configuration, which previously specified files and directories to ignore and a regex for dummy variable names. This results in broader linting coverage.
