### PR TITLE
Remove Repository Restrictor

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -69,7 +69,7 @@ def get_all_repos(github: Github) -> list[Repository]:
     """
     # Authenticate to GitHub
     repositories = github.search_repositories(
-        query="user:JackPlowman archived:false is:public DependabotTrigger",
+        query="user:JackPlowman archived:false is:public",
     )
     logger.info(
         "Retrieved repositories to analyse",


### PR DESCRIPTION
# Pull Request

## Description

This pull request makes a small change to the query used for retrieving repositories in the `get_all_repos` function. The change removes the `DependabotTrigger` filter, broadening the search to include all public, non-archived repositories for the user.