### PR TITLE
Add update only mode

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -14,6 +14,9 @@ install-browsers:
 run:
     uv run python -m src
 
+run-update-only:
+    UPDATE_GROUP_PULL_REQUESTS=true uv run python -m src
+
 # ------------------------------------------------------------------------------
 # Ruff - Python Linting and Formatting
 # ------------------------------------------------------------------------------

--- a/src/app.py
+++ b/src/app.py
@@ -12,6 +12,7 @@ from .summary import JobSummary
 
 logger: stdlib.BoundLogger = get_logger()
 STALE_PR_THRESHOLD_DAYS = 30
+UPDATE_GROUP_PULL_REQUESTS = getenv("UPDATE_GROUP_PULL_REQUESTS") in ["true", "True"]
 
 
 def app() -> None:
@@ -27,7 +28,8 @@ def app() -> None:
         repos = get_all_repos(github)
         for index, repo in enumerate(repos, start=1):
             pull_requests = get_pull_requests(github, repo.full_name)
-            close_group_pull_requests(pull_requests, repo.full_name)
+            if not UPDATE_GROUP_PULL_REQUESTS:
+                close_group_pull_requests(pull_requests, repo.full_name)
             warn_on_stale_pull_requests(pull_requests, repo.full_name, summary)
             trigger_dependabot(page, repo.full_name, summary)
             logger.info(


### PR DESCRIPTION
# Pull Request

## Description

This pull request introduces an environment variable to control whether group pull requests are closed during execution, and adds a new command to the `Justfile` for running the application with this behavior. The main changes focus on improving flexibility in handling group pull requests.

**Configuration and workflow improvements:**

* Added a new `run-update-only` command to the `Justfile`, which sets the `UPDATE_GROUP_PULL_REQUESTS` environment variable before running the app.
* Introduced the `UPDATE_GROUP_PULL_REQUESTS` environment variable in `src/app.py` to control whether group pull requests should be closed.
* Modified the main application logic to skip closing group pull requests when `UPDATE_GROUP_PULL_REQUESTS` is set, allowing for update-only runs.

Fixes #147 
